### PR TITLE
Fix IndexOutOfBoundsException in ShrinkIfPossible

### DIFF
--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -283,7 +283,7 @@ public class BoundsOctreeNode<T> {
 		if (BaseLength < (2 * minLength)) {
 			return this;
 		}
-		if (objects.Count == 0 && children != null && children.Length == 0) {
+		if (objects.Count == 0 && (children == null || children.Length == 0)) {
 			return this;
 		}
 

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -334,6 +334,11 @@ public class BoundsOctreeNode<T> {
 			return this;
 		}
 
+		// No objects in entire octree
+		if (bestFit == -1) {
+			return this;
+		}
+
 		// We have children. Use the appropriate child as the new root node
 		return children[bestFit];
 	}


### PR DESCRIPTION
The previous fix was incorrect. It would not early out in the case of objects.Count == 0 and children == null.

This was actually @dunity's original fix. I discussed with him before creating this PR.