### PR TITLE
Grow fix

### DIFF
--- a/Scripts/BoundsOctree.cs
+++ b/Scripts/BoundsOctree.cs
@@ -244,7 +244,7 @@ public class BoundsOctree<T> {
 		// Create a new, bigger octree root node
 		rootNode = new BoundsOctreeNode<T>(newLength, minSize, looseness, newCenter);
 
-		if (oldRoot.Count > 0)
+		if (oldRoot.HasAnyObjects())
 		{
 			// Create 7 new octree children to go with the old root as children of the new root
 			int rootPos = GetRootPosIndex(xDirection, yDirection, zDirection);

--- a/Scripts/BoundsOctree.cs
+++ b/Scripts/BoundsOctree.cs
@@ -244,23 +244,29 @@ public class BoundsOctree<T> {
 		// Create a new, bigger octree root node
 		rootNode = new BoundsOctreeNode<T>(newLength, minSize, looseness, newCenter);
 
-		// Create 7 new octree children to go with the old root as children of the new root
-		int rootPos = GetRootPosIndex(xDirection, yDirection, zDirection);
-		BoundsOctreeNode<T>[] children = new BoundsOctreeNode<T>[8];
-		for (int i = 0; i < 8; i++) {
-			if (i == rootPos) {
-				children[i] = oldRoot;
+		if (oldRoot.Count > 0)
+		{
+			// Create 7 new octree children to go with the old root as children of the new root
+			int rootPos = GetRootPosIndex(xDirection, yDirection, zDirection);
+			BoundsOctreeNode<T>[] children = new BoundsOctreeNode<T>[8];
+			for (int i = 0; i < 8; i++)
+			{
+				if (i == rootPos)
+				{
+					children[i] = oldRoot;
+				}
+				else
+				{
+					xDirection = i % 2 == 0 ? -1 : 1;
+					yDirection = i > 3 ? -1 : 1;
+					zDirection = (i < 2 || (i > 3 && i < 6)) ? -1 : 1;
+					children[i] = new BoundsOctreeNode<T>(rootNode.BaseLength, minSize, looseness, newCenter + new Vector3(xDirection * half, yDirection * half, zDirection * half));
+				}
 			}
-			else {
-				xDirection = i % 2 == 0 ? -1 : 1;
-				yDirection = i > 3 ? -1 : 1;
-				zDirection = (i < 2 || (i > 3 && i < 6)) ? -1 : 1;
-				children[i] = new BoundsOctreeNode<T>(rootNode.BaseLength, minSize, looseness, newCenter + new Vector3(xDirection * half, yDirection * half, zDirection * half));
-			}
-		}
 
-		// Attach the new children to the new root node
-		rootNode.SetChildren(children);
+			// Attach the new children to the new root node
+			rootNode.SetChildren(children);
+		}
 	}
 
 	/// <summary>

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -524,7 +524,7 @@ public class BoundsOctreeNode<T> {
 	/// Checks if this node or anything below it has something in it.
 	/// </summary>
 	/// <returns>True if this node or any of its children, grandchildren etc have something in them</returns>
-	public bool HasAnyObjects() {
+	internal bool HasAnyObjects() {
 		if (objects.Count > 0) return true;
 
 		if (children != null) {

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -9,8 +9,6 @@ public class BoundsOctreeNode<T> {
 	// Length of this node if it has a looseness of 1.0
 	public float BaseLength { get; private set; }
 
-	public float Count { get { return objects.Count; } }
-
 	// Looseness value for this node
 	float looseness;
 	// Minimum size for a node in this octree
@@ -526,7 +524,7 @@ public class BoundsOctreeNode<T> {
 	/// Checks if this node or anything below it has something in it.
 	/// </summary>
 	/// <returns>True if this node or any of its children, grandchildren etc have something in them</returns>
-	bool HasAnyObjects() {
+	public bool HasAnyObjects() {
 		if (objects.Count > 0) return true;
 
 		if (children != null) {

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -9,6 +9,8 @@ public class BoundsOctreeNode<T> {
 	// Length of this node if it has a looseness of 1.0
 	public float BaseLength { get; private set; }
 
+	public float Count { get { return objects.Count; } }
+
 	// Looseness value for this node
 	float looseness;
 	// Minimum size for a node in this octree


### PR DESCRIPTION
I discovered a bug when creating a couple of primitives far from the origin. If the first object you add to the octree requires it to grow, you end up with an octree node full of empty children. Later on, when removing an object (i.e. the playerhead, which is added and removed every frame), the ShrinkIfPossible method will mistakenly remove children with objects in them.

The fix is simply to not include the old root node if you are growing on an empty root.