### PR TITLE
Use a struct and RemoveAt for OctreeObject

### DIFF
--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -28,7 +28,7 @@ public class BoundsOctreeNode<T> {
 	const int numObjectsAllowed = 8;
 
 	// An object in the octree
-	class OctreeObject {
+	struct OctreeObject {
 		public T Obj;
 		public Bounds Bounds;
 	}
@@ -69,8 +69,10 @@ public class BoundsOctreeNode<T> {
 		bool removed = false;
 
 		for (int i = 0; i < objects.Count; i++) {
-			if (objects[i].Obj.Equals(obj)) {
-				removed = objects.Remove(objects[i]);
+			if (objects[i].Obj.Equals(obj))
+			{
+				removed = true;
+				objects.RemoveAt(i);
 				break;
 			}
 		}

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -31,6 +31,34 @@ public class BoundsOctreeNode<T> {
 	struct OctreeObject {
 		public T Obj;
 		public Bounds Bounds;
+
+		public override int GetHashCode()
+		{
+			var hashCode = Bounds.GetHashCode();
+
+			if (Obj != null)
+				hashCode ^= Obj.GetHashCode();
+
+			return hashCode;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+				return false;
+
+			if (!(obj is OctreeObject))
+				return false;
+
+			var other = (OctreeObject)obj;
+			if (Bounds != other.Bounds)
+				return false;
+
+			if (Obj == null && other.Obj == null)
+				return true;
+
+			return Obj.Equals(other.Obj);
+		}
 	}
 
 	/// <summary>
@@ -365,7 +393,7 @@ public class BoundsOctreeNode<T> {
 	// #### PRIVATE METHODS ####
 
 	/// <summary>
-	/// Set values for this node. 
+	/// Set values for this node.
 	/// </summary>
 	/// <param name="baseLengthVal">Length of this node, not taking looseness into account.</param>
 	/// <param name="minSizeVal">Minimum size of nodes in this octree.</param>
@@ -429,7 +457,7 @@ public class BoundsOctreeNode<T> {
 					bestFitChild = BestFitChild(existingObj.Bounds);
 					// Does it fit?
 					if (Encapsulates(children[bestFitChild].bounds, existingObj.Bounds)) {
-						children[bestFitChild].SubAdd(existingObj.Obj, existingObj.Bounds); // Go a level deeper					
+						children[bestFitChild].SubAdd(existingObj.Obj, existingObj.Bounds); // Go a level deeper
 						objects.Remove(existingObj); // Remove from here
 					}
 				}


### PR DESCRIPTION
This was a performance improvement I made a while back while deep profiling EXR. There is a little bit of GC churn related to the fact that OctreeObject was a class. We never relied on it being null, so this should be a safe change.

The second change, using RemoveAt, should be faster, as the Remove operator checks equality on each element of the list.